### PR TITLE
Add basic Flutter first page UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 a3wdh/a3wdh is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## App UI
+
+A simple first page UI is included in [lib/main.dart](lib/main.dart). It shows a welcome message and a "Get Started" button.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'First Page Demo',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const FirstPage(),
+    );
+  }
+}
+
+class FirstPage extends StatelessWidget {
+  const FirstPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Welcome to my app!',
+              style: TextStyle(fontSize: 24),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text('Get Started'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a Flutter UI example for the app
- mention the UI in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409841914483278fa368a991a25053