### PR TITLE
Enable binary diff via textconv helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use custom textconv for binary files so diffs show hex output
+*.bin diff=hexdiff

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 - 💞️ I’m looking to collaborate on flutter app a junior developer 
 - 📫 How to reach me a3wdh@icloud.com
 
+## Viewing binary diffs
+
+The environment used for this project does not show binary diffs by default.
+To see a textual representation of changes to `.bin` files, configure Git to
+use the helper script included in this repository:
+
+```bash
+git config diff.hexdiff.textconv "scripts/hexdiff.sh"
+```
+
+After running that command, `git diff` will display hex dumps for binary files,
+making it easier to review their changes.
+
 <!---
 a3wdh/a3wdh is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.

--- a/scripts/hexdiff.sh
+++ b/scripts/hexdiff.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Convert binary file to hex dump for diff output
+hexdump -C "$1"


### PR DESCRIPTION
## Summary
- add `.gitattributes` to register a diff driver for `.bin` files
- provide a helper script that displays hex dumps so binary diffs are readable
- document the configuration steps in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409a54a110832787eb0a9290b914f9